### PR TITLE
Fix unification of pointer to void and pointer to an unknown type

### DIFF
--- a/src/Kit/Compiler/Unify.hs
+++ b/src/Kit/Compiler/Unify.hs
@@ -123,6 +123,7 @@ unifyBase ctx tctx strict a' b' = do
       if impl then return $ Just [] else fallBackToAbstractParent a b
     (_, TypeTraitConstraint v) -> r b a
     (TypeBasicType a, TypeBasicType b) -> return $ unifyBasic a b
+    (TypePtr a@(TypeBasicType BasicTypeVoid), TypePtr b@(TypeTypeVar _)) -> r a b
     (TypePtr (TypeBasicType BasicTypeVoid), TypePtr _) -> return $ Just []
     (TypePtr (TypeBasicType BasicTypeVoid), TypeArray _ _) -> return $ Just []
     (TypePtr _, TypePtr (TypeBasicType BasicTypeVoid)) -> return $ Just []

--- a/std/kit/mem.kit
+++ b/std/kit/mem.kit
@@ -116,7 +116,7 @@ implement Allocator for LinearAllocator {
             Some(x) => return x;
             default => {
                 panic("failed to allocate from LinearAllocator");
-                return null: Ptr[Void];
+                return null;
             }
         }
     }
@@ -129,7 +129,7 @@ implement Allocator for StackAllocator {
             Some(x) => return x;
             default => {
                 panic("failed to allocate from StackAllocator");
-                return null: Ptr[Void];
+                return null;
             }
         }
     }


### PR DESCRIPTION
Previously the code would unconditionally refuse to unify pointer to void
with any other pointer. That lead to a test failure on Mac OS:

    tests/Kit/CompilerSpec.hs:52:11:
    1) Kit.Compiler, Successful compile tests, tests/compile-src/std/sys/utils.kit
       expected: Nothing
        but got: Just KitErrors [KitErrors [BasicError "The type of this expression is ambiguous; not enough information to infer a type for type var #153.\n\nTry adding a type annotation: `expression: Type`" (Just @std/kit/sys/utils.kit:16:23-26)]]

The compiler output when called manually:

    $ kitc -s ./std -s ./tests/compile-src/std/sys utils
    [2018-10-03 19:59:42.650042] ===> parsing and building module graph
    [2018-10-03 19:59:42.665697] ===> processing C includes
    [2018-10-03 19:59:43.087041] ===> resolving module types
    [2018-10-03 19:59:43.090047] ===> typing module content
    [2018-10-03 19:59:43.093123] ===> generating intermediate representation
    ----------------------------------------
    Error: ./std/kit/sys/utils.kit:16: The type of this expression is ambiguous; not enough information to infer a type for type var #153.

    Try adding a type annotation: `expression: Type`

      @./std/kit/sys/utils.kit:16:23-26
          16        gettimeofday(&tv, null);
                                      ^^^^

    [2018-10-03 19:59:43.097176] ===> total time: 0.4465s
    [2018-10-03 19:59:43.097729] ERR: compilation failed (1 errors)

The test wasn't failing on Linux, because on Linux gettimeofday is
declared like this:

    extern int gettimeofday (struct timeval *__restrict __tv,
        __timezone_ptr_t __tz) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__nonnull__ (1)));

While on Mac OS gettimeofday is declared as:

    int gettimeofday(struct timeval *restrict, void *restrict);

Since this case is being handled now I let myself remove two no longer
necessary Ptr[Void] annotations.