### PR TITLE
Fix type unification regression

### DIFF
--- a/src/Kit/Compiler/Typers/ConvertExpr.hs
+++ b/src/Kit/Compiler/Typers/ConvertExpr.hs
@@ -179,8 +179,7 @@ convertExpr ctx tctx mod e = do
       t' <- resolveType ctx tctx mod t
       return $ m (Implicit t') t'
     Null -> do
-      t <- mtv
-      return $ m Null $ TypePtr t
+      return $ m Null $ TypePtr voidType
     Empty -> do
       t <- mtv
       return $ m Empty t

--- a/src/Kit/Compiler/Unify.hs
+++ b/src/Kit/Compiler/Unify.hs
@@ -123,7 +123,6 @@ unifyBase ctx tctx strict a' b' = do
       if impl then return $ Just [] else fallBackToAbstractParent a b
     (_, TypeTraitConstraint v) -> r b a
     (TypeBasicType a, TypeBasicType b) -> return $ unifyBasic a b
-    (TypePtr a@(TypeBasicType BasicTypeVoid), TypePtr b@(TypeTypeVar _)) -> r a b
     (TypePtr (TypeBasicType BasicTypeVoid), TypePtr _) -> return $ Just []
     (TypePtr (TypeBasicType BasicTypeVoid), TypeArray _ _) -> return $ Just []
     (TypePtr _, TypePtr (TypeBasicType BasicTypeVoid)) -> return $ Just []

--- a/tests/compile-src/issues/issue8.kit
+++ b/tests/compile-src/issues/issue8.kit
@@ -1,0 +1,5 @@
+function main() {
+    var a;
+    var b: Ptr[Void] = &a;
+    a = 1;
+}


### PR DESCRIPTION
A patch introduced in b3cb13a73d09770138f81d0757105807bb1bd7f3 (#8)
broke a previously working use case included in issue8.kit:

    Error: ./issue8.kit:4: Assigned value must match the type of the lvalue it's assigned to:

      @./test.kit:4:9
           4        a = 1;
                        ^

        Expected type:  Void
          Actual type:  Int8

Changing the type of null to a pointer to void instead of a generic
pointer was suggested in #8 instead (discussion) and it really seems
like it both does what #8 did and fixes the regression.