### PR TITLE
Fix box test on Mac OS

### DIFF
--- a/tests/compile-src/box.kit
+++ b/tests/compile-src/box.kit
@@ -1,3 +1,5 @@
+include "inttypes.h";
+
 struct MyStruct {
     public var a: Int;
     public var b: Float;
@@ -15,8 +17,7 @@ implement Greeter for Int {
 
 implement Greeter for Int64 {
     public function greet() {
-        // FIXME: needs PRId64, but no way to represent that in Kit
-        printf("Hellooo from Int64 %li\n", this);
+        printf(```"Hellooo from Int64 %" PRId64 "\n"```: CString, this);
     }
 }
 


### PR DESCRIPTION
The test was failing with:

    tests/Kit/CompilerSpec.hs:41:7:
    1) Kit.Compiler, Successful compile tests, tests/compile-src/box.kit
         uncaught exception: IOException of type OtherError
         callProcess: /usr/bin/cc "-Werror" "-Ibuild/include" "-c" "build/lib/box/kit_Greeter.c" "-o" "build/obj/box/kit_Greeter.o" "-D_GNU_SOURCE" "-D_BSD_SOURCE" "-D_DEFAULT_SOURCE" "-std=c99" "-pedantic" "-O3" "-Os" "-U__BLOCKS__" "-Wno-expansion-to-defined" "-Wno-gnu-zero-variadic-macro-arguments" (exit 1): failed

The cc output (obtained manually) was as follows:

    build/lib/box/kit_Greeter.c:17:53: error: format specifies type 'long' but the argument has type 'int64_t' (aka 'long long') [-Werror,-Wformat]
            printf((char *) "Hellooo from Int64 %li\n", *__this);
                                                ~~~     ^~~~~~~
                                                %lli
    1 error generated.

Triple backticks syntax[2] provides a way to just use a macro[2] that
provides platform independent behavior here.

[1] 967c0e854f2a1c41db1da64d90d892e1c1c29e6e
[2] https://en.cppreference.com/w/cpp/types/integer