### PR TITLE
Add support for passing file names to kitc

### DIFF
--- a/bin/kitc/Main.hs
+++ b/bin/kitc/Main.hs
@@ -44,7 +44,7 @@ options =
           str
           (  metavar "MODULE"
           <> help
-               "module containing the main() function (for binaries) or compilation entry point for libraries"
+               "module or file containing the main() function (for binaries) or compilation entry point for libraries"
           )
     <*> switch (long "version" <> help "show the version number and exit")
     <*> (length <$> many
@@ -155,18 +155,15 @@ main = do
       baseContext     <- newCompileContext
       defaultIncludes <- defaultIncludePaths
       let
+        (mainModule, sourcePaths) = decideModuleAndSourcePaths (s_pack $ optMainModule opts) (optSourcePaths opts)
         ctx = baseContext
-          { ctxMainModule   = parseModulePath $ s_pack $ optMainModule opts
+          { ctxMainModule   = parseModulePath $ mainModule
           , ctxIsLibrary    = optIsLibrary opts
           , ctxBuildDir     = optBuildDir opts
           , ctxOutputPath   = optOutputPath opts
           , ctxCompilerPath = optCompilerPath opts
           , ctxIncludePaths = optIncludePaths opts ++ defaultIncludes
-          , ctxSourcePaths  = (if null $ optSourcePaths opts
-                                then ["src"]
-                                else optSourcePaths opts
-                              )
-            ++ stdPath
+          , ctxSourcePaths  = sourcePaths ++ stdPath
           , ctxDefines      = map
             (\s -> (takeWhile (/= '=') s, drop 1 $ dropWhile (/= '=') s))
             (optDefines opts)

--- a/src/Kit/Compiler.hs
+++ b/src/Kit/Compiler.hs
@@ -175,25 +175,37 @@ compilerSanityChecks ctx = do
 
 
 decideModuleAndSourcePaths :: Str -> [FilePath] -> (Str, [FilePath])
-decideModuleAndSourcePaths mod paths = do
+decideModuleAndSourcePaths mod paths =
   let
-    normPaths = [dropTrailingPathSeparator $ normalise p | p <- paths]
-    modAsPath = normalise $ s_unpack mod
+    normPaths      = [ dropTrailingPathSeparator $ normalise p | p <- paths ]
+    modAsPath      = normalise $ s_unpack mod
     modAsPathNoExt = case stripExtension ".kit" modAsPath of
-                       Just p -> p
-                       Nothing -> modAsPath
+      Just p  -> p
+      Nothing -> modAsPath
     modDir = case init $ splitDirectories modAsPath of
-               [] -> "."
-               p -> joinPath p
-    normPathsWithExtra = (if s_isSuffixOf ".kit" mod && not modReachableAlready
-                            then [modDir]
-                            else []
-                         ) ++ normPaths
-    inputPathsThatCanLeadToMod = [p | p <- normPaths, isPrefixOf (splitDirectories p) (splitDirectories modAsPath)]
+      [] -> "."
+      p  -> joinPath p
+    normPathsWithExtra =
+      (if s_isSuffixOf ".kit" mod && not modReachableAlready
+          then [modDir]
+          else []
+        )
+        ++ normPaths
+    inputPathsThatCanLeadToMod =
+      [ p
+      | p <- normPaths
+      , isPrefixOf (splitDirectories p) (splitDirectories modAsPath)
+      ]
     modPathSplit = s_split '/' mod
-    actualMod = case inputPathsThatCanLeadToMod of
-                  [] -> s_pack $ takeFileName modAsPathNoExt
-                  -- What should be done if multiple source paths can lead to the file we specified?
-                  _ -> s_join "." $ map s_pack $ splitDirectories $ makeRelative (head inputPathsThatCanLeadToMod) $ modAsPathNoExt
+    actualMod    = case inputPathsThatCanLeadToMod of
+      [] -> s_pack $ takeFileName modAsPathNoExt
+      -- What should be done if multiple source paths can lead to the file we specified?
+      _ ->
+        s_join "."
+          $ map s_pack
+          $ splitDirectories
+          $ makeRelative (head inputPathsThatCanLeadToMod)
+          $ modAsPathNoExt
     modReachableAlready = not $ null inputPathsThatCanLeadToMod
-  (actualMod, if null normPathsWithExtra then ["src"] else normPathsWithExtra)
+  in
+    (actualMod, if null normPathsWithExtra then ["src"] else normPathsWithExtra)

--- a/src/Kit/Str.hs
+++ b/src/Kit/Str.hs
@@ -24,3 +24,5 @@ s_concat = B.concat
 s_split = B.split
 s_join = B.intercalate
 s_hash s = s_take 16 $ B.fromChunks [encode $ hashlazy $ s]
+s_isSuffixOf = B.isSuffixOf
+s_isPrefixOf = B.isSuffixOf

--- a/tests/Kit/CompilerSpec.hs
+++ b/tests/Kit/CompilerSpec.hs
@@ -80,3 +80,23 @@ spec = parallel $ do
             Right ()  -> Nothing
           )
           `shouldBe` Nothing
+
+  describe "Test decideModuleAndSourcePaths" $ do
+    let testData = [ -- We default to src if we have no source paths and a file wasn't specified directly
+                     ("main", [], ("main", ["src"]))
+
+                   , ("main.kit", [], ("main", ["."]))
+                   , ("src/main.kit", [], ("main", ["src"]))
+
+                     -- To make sure we don't generate redundant entries in case of paths that need normalization.
+                     -- Also that we normalize paths.
+                   , ("./src/main.kit", [], ("main", ["src"]))
+                   , ("src/main.kit", ["./src/"], ("main", ["src"]))
+
+                   , ("src/pkg/main.kit", [], ("main", ["src/pkg"]))
+                   , ("src/pkg/main.kit", ["src"], ("pkg.main", ["src"]))
+                   ]
+    forM_ (testData) $ \d -> do
+      let (mod, paths, result) = d
+      it (show (mod, paths)) $ do
+        decideModuleAndSourcePaths mod paths `shouldBe` result


### PR DESCRIPTION
The default source path ("src") behavior has been modified slightly to
not include the default path when we can infer a different path from the
file passed.

Closes #21 and follows up on https://github.com/kitlang/kit/issues/21#issuecomment-433305492

Feel free to modify the patch to your taste as I realise my Haskell is clunky.