### PR TITLE
Fixed infinite loop in Vector.ensureSize when length == 0

### DIFF
--- a/std/kit/vector.kit
+++ b/std/kit/vector.kit
@@ -48,6 +48,9 @@ struct Vector[T] {
     function ensureSize(n: Int): Void {
         if this.data.length < n {
             var l = this.length;
+            if l == 0 {
+                l = 1;
+            }
             while l < n {
                 l <<= 1;
             }


### PR DESCRIPTION
Calling `push` on a `Vector` that was created with an initial size of 0 caused `ensureSize` to left shift 0 infinitely. I put a simple check before the loop to increment the size if it's 0.