### PR TITLE
Fix Hangman sample bug

### DIFF
--- a/samples/hangman.kit
+++ b/samples/hangman.kit
@@ -89,7 +89,10 @@ function main() {
     game.word = word;
     game.guesses = Empty;
     game.wrongGuesses = 0;
-    game.filled[0] = 0;
+
+    for i in 0 ... word.length {
+        game.filled[i] = 0;
+    }
 
     var success: Bool = false;
 


### PR DESCRIPTION
I found when testing the Hangman sample that the game state description contained some random letters and symbols instead of underscores:
<img width="697" alt="Screen Shot 2019-03-15 at 5 26 37 PM" src="https://user-images.githubusercontent.com/8942401/54464079-a18cf680-474b-11e9-9920-5c48d549aa66.png">

This appears to be because the `Game.filled` CArray wasn't properly initialized, so it contained garbage data. This change fixes the game so the blanks appear as intended.

Note that I'm very new to Kit, so if there's a better way to fix this, I'd be curious to learn what the solution is. :)